### PR TITLE
[Resource] 디자인시스템 Color 추가

### DIFF
--- a/Umat/Projects/Shared/DesignSystem/Sources/Colors/Extensions+/Color+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Colors/Extensions+/Color+Extension.swift
@@ -1,0 +1,35 @@
+//
+//  Color+Extension.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/4/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int = UInt64()
+        let a, r, g, b: UInt64
+        
+        Scanner(string: hex).scanHexInt64(&int)
+        
+        switch hex.count {
+        case 3:
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6:
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8:
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+        
+        self.init(.sRGB, red: Double(r) / 255,
+                  green: Double(g) / 255,
+                  blue:  Double(b) / 255,
+                  opacity: Double(a) / 255)
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Colors/Extensions+/ShapeColor+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Colors/Extensions+/ShapeColor+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  Color.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/3/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+public extension ShapeStyle where Self == Color {
+    static func colors(_ color: Colors) -> Color {
+        return .init(hex: color.hex)
+    }
+    
+    static func gradient(leading: Colors = .orange400, trailing: Colors = .blue300) -> LinearGradient {
+        return .init(gradient: Gradient(colors: [.colors(leading), .colors(trailing)]),
+              startPoint: .leading,
+              endPoint: .trailing)
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Colors/Extensions+/ShapeColor+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Colors/Extensions+/ShapeColor+Extension.swift
@@ -15,7 +15,7 @@ public extension ShapeStyle where Self == Color {
     
     static func gradient(leading: Colors = .orange400, trailing: Colors = .blue300) -> LinearGradient {
         return .init(gradient: Gradient(colors: [.colors(leading), .colors(trailing)]),
-              startPoint: .leading,
-              endPoint: .trailing)
+                     startPoint: .leading,
+                     endPoint: .trailing)
     }
 }

--- a/Umat/Projects/Shared/DesignSystem/Sources/Colors/Models/Colors.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Colors/Models/Colors.swift
@@ -1,0 +1,154 @@
+//
+//  Colors.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/3/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+public enum Colors {
+    
+    // MARK: - Gray
+    case gray50
+    case gray100
+    case gray200
+    case gray300
+    case gray400
+    case gray500
+    case gray600
+    case gray700
+    case gray800
+    case gray900
+    case gray950
+    
+    // MARK: - UserColor
+    case orange50
+    case orange100
+    case orange200
+    case orange300
+    case orange400
+    case orange500
+    case orange600
+    case orange700
+    case orange800
+    case orange900
+    case orange950
+    case blue50
+    case blue100
+    case blue200
+    case blue300
+    case blue400
+    case blue500
+    case blue600
+    case blue700
+    case blue800
+    case blue900
+    case blue950
+    case both
+    
+    // MARK: - StateColor
+    case error
+    case success
+    
+    // MARK: - Reaction
+    case like
+    case love
+    case notGood
+    case soso
+    
+    var hex: String {
+        switch self {
+        
+        // MARK: Gray
+        case .gray50:
+            return "#F9FAFB"
+        case .gray100:
+            return "#F3F4F6"
+        case .gray200:
+            return "#E5E7EB"
+        case .gray300:
+            return "#D1D5DB"
+        case .gray400:
+            return "#9CA3AF"
+        case .gray500:
+            return "#6B7280"
+        case .gray600:
+            return "#4B5563"
+        case .gray700:
+            return "#374151"
+        case .gray800:
+            return "#1F2937"
+        case .gray900:
+            return "#111827"
+        case .gray950:
+            return "#030712"
+            
+        // MARK: UserColor
+        case .orange50:
+            return "#FFF5EC"
+        case .orange100:
+            return "#FFE9D3"
+        case .orange200:
+            return "#FFCFA5"
+        case .orange300:
+            return "#FFAD6D"
+        case .orange400:
+            return "#FF7E32"
+        case .orange500:
+            return "#FF5B0A"
+        case .orange600:
+            return "#FF4000"
+        case .orange700:
+            return "#CC2B02"
+        case .orange800:
+            return "#A1220B"
+        case .orange900:
+            return "#821F0C"
+        case .orange950:
+            return "#460C04"
+        case .blue50:
+            return "#EEF2FF"
+        case .blue100:
+            return "#E0E7FF"
+        case .blue200:
+            return "#C7D2FE"
+        case .blue300:
+            return "#A5B4FC"
+        case .blue400:
+            return "#818CF8"
+        case .blue500:
+            return "#6366F1"
+        case .blue600:
+            return "#4F46E5"
+        case .blue700:
+            return "#4338CA"
+        case .blue800:
+            return "#3730A3"
+        case .blue900:
+            return "#312E81"
+        case .blue950:
+            return "#1E1B4B"
+        case .both:
+            return "#a855f7"
+            
+        // MARK: StateColor
+        case .error:
+            return "#F43F5E"
+        case .success:
+            return "#3B82F6"
+            
+        // MARK: Reaction
+        case .like:
+            return "#FF4949"
+        case .love:
+            return "#FDD842"
+        case .notGood:
+            return "#FF85B9"
+        case .soso:
+            return "#01E39B"
+        }
+    }
+}
+

--- a/Umat/Projects/Shared/DesignSystem/Sources/Colors/Models/Colors.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Colors/Models/Colors.swift
@@ -152,3 +152,8 @@ public enum Colors {
     }
 }
 
+public extension Colors {
+    var color: Color {
+        .colors(self)
+    }
+}


### PR DESCRIPTION
## 코드를 추가 및 수정한 이유
- 프로젝트 간 사용될 Color를 추가하기 위함.
  - Color 사용을 용이하게 하기 위해 메서드 추가

## 작업 내용
- Figma에서 제시된 디자인 시스템 내 Color를 사용할 수 있도록 세팅했습니다.
  - 네이밍도 동일하게 **Figma에서 제시된 네이밍을 적용**하였습니다.
  - Gray(11종)
  - UserColor: Orange, Blue 각 11종 + Both
  - StateColor(2종)
  - ReactionColor(4종)
  - Gradient(1종)
- Color Extension에서 Hex값을 이용해 Color를 사용할 수 있도록 세팅하였습니다.

### 단일 컬러 사용
- **ShapeStyle extension을 이용**해 `Color.colors(.blue100)`이 아닌, `.colors(.blue100)`으로 호출이 가능토록 구현함으로써, 사용 편의를 높였습니다.
  - Color.colors(.blue100) 도 사용 가능합니다.
  - 사용 예제는 다음과 같습니다.
  - ```swift
     import DesignSystem

     // MARK: - 사용예제 1
     Text("Eddy")
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .foregroundStyle(.colors(.both))
       .background(.colors(.blue100))

     // MARK: - 사용예제 2
     Text("Eddy")
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .foregroundStyle(Color.colors(.both))
       .background(Color.colors(.blue100))

     // MARK: - 사용예제 3
     Color.colors(.blue100)
     ```

### Gradient 사용
- 또한, 현재 앱에서 사용이 예정되어 있는 gradient Color는 .orange400과 .blue300만 사용되어 있기 때문에, **gradient() 의 argument에 대해 default Value를 제공함**으로써, **평소 사용 간에는 `.gradient()`만으로도 사용 가능하도록 구현**하였습니다.
  - **필요 시, parameter를 활성화**하여 leading, trailing에 대한 2가지 Color를 반영할 수 있습니다. 
  - 사용 예제는 다음과 같습니다.
  - ```swift
     import DesignSystem

     // MARK: - 사용예제 1
     Text("Eddy")
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .foregroundStyle(.gradient())
       .background(.gradient(leading: .blue900, trailing: .orange50))

     // MARK: - 사용예제 2
     Text("Eddy")
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .foregroundStyle(Color.gradient())
       .background(Color.gradient(leading: .blue900, trailing: .orange50))

     // MARK: - 사용예제 3
     Color.gradient()
     Color.gradient(leading: .blue900, trailing: .orange50)
     ```

### 기타 사용 예
- Colors enum을 사용하여 Colors.blue100.color 처럼 Color타입을 직접 호출할 수 있습니다.
  - hex값을 외부에서 직접 호출하는 상황은 없을 것으로 판단해 접근제어를 internal로 유지하였습니다.
  - 사용 예제는 다음과 같습니다.
  - ```swift
     import DesignSystem

     // MARK: - 사용예제 1
     Text("Eddy")
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .foregroundStyle(Colors.blue50.color)
       .background(Colors.orange500.color)

     // MARK: - 사용예제 2
     Colors.blue300.color
     ```

## 작업 간 어려움
- 없음

## 기타
- 편리하고 다양하게 사용할 수 있도록 구현해봤지만, 사용 간 어려움이 있는지 확인해주시면 감사하겠습니다.

## Close issue
Close #3.