### PR TITLE
[Feature] 마이페이지에서 사용할 모델 작성

### DIFF
--- a/Umat/Projects/Shared/Entity/Sources/Couple.swift
+++ b/Umat/Projects/Shared/Entity/Sources/Couple.swift
@@ -12,7 +12,7 @@ import Foundation
 /// 나의 정보 및 기념일을 바꾸었을 때 반영할 수 있도록 var로 했습니다.
 /// id나 you의 정보는 내가 임의로 바꿀 수 없도록 let으로 지정했습니다.
 /// 이 부분은 백엔드 단에서 내려줄 때만 새로운 객체로 수정하면 됩니다.
-struct Couple {
+public struct Couple {
     private let id: String
     public private(set) var me: UserInfo
     public let you: UserInfo

--- a/Umat/Projects/Shared/Entity/Sources/Couple.swift
+++ b/Umat/Projects/Shared/Entity/Sources/Couple.swift
@@ -17,12 +17,14 @@ struct Couple {
     public private(set) var me: UserInfo
     public let you: UserInfo
     public private(set) var anniversary: Date
+    public private(set) var wishlist: [Place]
     
-    public init(id: String, me: UserInfo, you: UserInfo, anniversary: Date) {
+    public init(id: String, me: UserInfo, you: UserInfo, anniversary: Date, wishlist: [Place]) {
         self.id = id
         self.me = me
         self.you = you
         self.anniversary = anniversary
+        self.wishlist = wishlist
     }
     
     public mutating func changeMyInfo(me newInfo: UserInfo) {
@@ -34,4 +36,7 @@ struct Couple {
         anniversary = newDate
         // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
     }
+    
+    // TODO: "우리" 리스트에 채워넣거나 삭제하는 메서드
+    // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
 }

--- a/Umat/Projects/Shared/Entity/Sources/Couple.swift
+++ b/Umat/Projects/Shared/Entity/Sources/Couple.swift
@@ -1,0 +1,37 @@
+//
+//  Couple.swift
+//  Entity
+//
+//  Created by Gordon Choi on 2/13/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import Foundation
+
+/// 커플을 위한 모델입니다.
+/// 나의 정보 및 기념일을 바꾸었을 때 반영할 수 있도록 var로 했습니다.
+/// id나 you의 정보는 내가 임의로 바꿀 수 없도록 let으로 지정했습니다.
+/// 이 부분은 백엔드 단에서 내려줄 때만 새로운 객체로 수정하면 됩니다.
+struct Couple {
+    private let id: String
+    public private(set) var me: UserInfo
+    public let you: UserInfo
+    public private(set) var anniversary: Date
+    
+    public init(id: String, me: UserInfo, you: UserInfo, anniversary: Date) {
+        self.id = id
+        self.me = me
+        self.you = you
+        self.anniversary = anniversary
+    }
+    
+    public mutating func changeMyInfo(me newInfo: UserInfo) {
+        me = newInfo
+        // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
+    }
+    
+    public mutating func changeAnniversary(anniversary newDate: Date) {
+        anniversary = newDate
+        // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
+    }
+}

--- a/Umat/Projects/Shared/Entity/Sources/Place.swift
+++ b/Umat/Projects/Shared/Entity/Sources/Place.swift
@@ -17,17 +17,19 @@ public struct Place: Equatable {
     public let closingHour: String
     public let grade: Double
     public let location: Location
+    public let imageURL: URL?
     
     public struct Location: Equatable {
         public let latitude: Double
         public let longitude: Double
     }
     
-    public init(name: String, openingHour: String, closingHour: String, grade: Double, latitude: Double, longitude: Double) {
+    public init(name: String, openingHour: String, closingHour: String, grade: Double, latitude: Double, longitude: Double, imageURL: URL?) {
         self.name = name
         self.openingHour = openingHour
         self.closingHour = closingHour
         self.grade = grade
         self.location = Location(latitude: latitude, longitude: longitude)
+        self.imageURL = imageURL
     }
 }

--- a/Umat/Projects/Shared/Entity/Sources/Place.swift
+++ b/Umat/Projects/Shared/Entity/Sources/Place.swift
@@ -1,0 +1,33 @@
+//
+//  Place.swift
+//  Entity
+//
+//  Created by Gordon Choi on 2/13/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import Foundation
+
+/// 장소 모델입니다.
+/// 구글 장소 api에 요청한 결과를 토대로 가져옵니다.
+/// CoreLocation을 아직 사용하지 않습니다. 임시로 위치 타입을 정해 두었습니다.
+public struct Place {
+    public let name: String
+    public let openingHour: String
+    public let closingHour: String
+    public let grade: Double
+    public let location: Location
+    
+    public struct Location {
+        public let latitude: Double
+        public let longitude: Double
+    }
+    
+    public init(name: String, openingHour: String, closingHour: String, grade: Double, latitude: Double, longitude: Double) {
+        self.name = name
+        self.openingHour = openingHour
+        self.closingHour = closingHour
+        self.grade = grade
+        self.location = Location(latitude: latitude, longitude: longitude)
+    }
+}

--- a/Umat/Projects/Shared/Entity/Sources/Place.swift
+++ b/Umat/Projects/Shared/Entity/Sources/Place.swift
@@ -11,14 +11,14 @@ import Foundation
 /// 장소 모델입니다.
 /// 구글 장소 api에 요청한 결과를 토대로 가져옵니다.
 /// CoreLocation을 아직 사용하지 않습니다. 임시로 위치 타입을 정해 두었습니다.
-public struct Place {
+public struct Place: Equatable {
     public let name: String
     public let openingHour: String
     public let closingHour: String
     public let grade: Double
     public let location: Location
     
-    public struct Location {
+    public struct Location: Equatable {
         public let latitude: Double
         public let longitude: Double
     }

--- a/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
+++ b/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
@@ -14,12 +14,14 @@ import Foundation
 public struct UserInfo {
     private let id: String
     public private(set) var name: String
+    public private(set) var birthday: Date
     public private(set) var allergicFoods: [AllergicFood]
     public private(set) var wishlist: [Place]
     
-    public init(id: String, name: String, allergicFoods: [AllergicFood], wishlist: [Place]) {
+    public init(id: String, name: String, birthday: Date, allergicFoods: [AllergicFood], wishlist: [Place]) {
         self.id = id
         self.name = name
+        self.birthday = birthday
         self.allergicFoods = allergicFoods
         self.wishlist = wishlist
     }

--- a/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
+++ b/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+/// 사용자 한 명에 대한 정보입니다.
+/// id값은 바뀌면 안 되므로 let입니다.
+/// 이름이나 알러지 품목은 바뀔 수 있으므로 var로 하고, 수정 메서드를 작성했습니다.
 public struct UserInfo {
     private let id: String
     public private(set) var name: String
@@ -21,13 +24,16 @@ public struct UserInfo {
     
     public mutating func changeName(name newName: String) {
         name = newName
+        // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
     }
     
     public mutating func changeAllergicFoods(foods newAllergicFoods: [AllergicFood]) {
         allergicFoods = newAllergicFoods
+        // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
     }
 }
 
+/// 식약처에서 제공하는 알러지 품목에 관한 목록입니다.
 public enum AllergicFood: String, CaseIterable {
     case crab = "게"
     case mackerel = "고등어"

--- a/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
+++ b/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
@@ -1,0 +1,53 @@
+//
+//  UserInfo.swift
+//  Entity
+//
+//  Created by Gordon Choi on 2/13/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import Foundation
+
+public struct UserInfo {
+    private let id: String
+    public private(set) var name: String
+    public private(set) var allergicFoods: [AllergicFood]
+    
+    public init(id: String, name: String, allergicFoods: [AllergicFood]) {
+        self.id = id
+        self.name = name
+        self.allergicFoods = allergicFoods
+    }
+    
+    public mutating func changeName(name newName: String) {
+        name = newName
+    }
+    
+    public mutating func changeAllergicFoods(foods newAllergicFoods: [AllergicFood]) {
+        allergicFoods = newAllergicFoods
+    }
+}
+
+public enum AllergicFood: String, CaseIterable {
+    case crab = "게"
+    case mackerel = "고등어"
+    case oyster = "굴"
+    case eggs = "난류"
+    case chicken = "닭고기"
+    case soybean = "대두"
+    case pork = "돼지고기"
+    case peanut = "땅콩"
+    case buckwheat = "메밀"
+    case wheat = "밀"
+    case peach = "복숭아"
+    case shrimp = "새우"
+    case beef = "쇠고기"
+    case sulfurousAcids = "아황산 포함 식품"
+    case squid = "오징어"
+    case milk = "우유"
+    case abalone = "전복"
+    case shellfishes = "조개류"
+    case tomato = "토마토"
+    case walnut = "호두"
+    case mussel = "홍합"
+}

--- a/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
+++ b/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
@@ -15,11 +15,13 @@ public struct UserInfo {
     private let id: String
     public private(set) var name: String
     public private(set) var allergicFoods: [AllergicFood]
+    public private(set) var wishlist: [Place]
     
-    public init(id: String, name: String, allergicFoods: [AllergicFood]) {
+    public init(id: String, name: String, allergicFoods: [AllergicFood], wishlist: [Place]) {
         self.id = id
         self.name = name
         self.allergicFoods = allergicFoods
+        self.wishlist = wishlist
     }
     
     public mutating func changeName(name newName: String) {
@@ -29,6 +31,16 @@ public struct UserInfo {
     
     public mutating func changeAllergicFoods(foods newAllergicFoods: [AllergicFood]) {
         allergicFoods = newAllergicFoods
+        // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
+    }
+    
+    public mutating func addPlace(place: Place) {
+        wishlist.append(place)
+        // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
+    }
+    
+    public mutating func deletePlace(place: Place) {
+        wishlist = wishlist.filter { $0 != place }
         // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
     }
 }

--- a/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
+++ b/Umat/Projects/Shared/Entity/Sources/UserInfo.swift
@@ -31,6 +31,11 @@ public struct UserInfo {
         // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
     }
     
+    public mutating func changeBirthday(date newBirthday: Date) {
+        birthday = newBirthday
+        // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)
+    }
+    
     public mutating func changeAllergicFoods(foods newAllergicFoods: [AllergicFood]) {
         allergicFoods = newAllergicFoods
         // TODO: 서버에 반영하는 과정도 필요합니다 (feature 단에서 수행할 가능성이 높습니다)


### PR DESCRIPTION
## ❗️ 코드를 추가 및 수정한 이유
- 마이페이지에서 표시할 내용들에 관한 데이터 타입이 필요하여, 앱 전반적으로 사용할 Entity 모델의 형태로 구현하였습니다.

## 🧾 작업 내용
### Entity
- **UserInfo**
    - 유저 개인을 나타내는 모델 작성: id, 이름, 생일, 알러지, 가고 싶은 장소 프로퍼티
- **Couple**
    - 커플을 나타내는 Couple 모델 작성: 나, 너, 기념일, 우리가 가고 싶은 곳 프로퍼티
- **AllergicFoods**
    - 알러지 케이스를 나타내는 타입 작성
- **Place**
    - 장소 모델 작성: 이름, 영업 시작 시간, 영업 끝나는 시간, 별점, 위치, 식당 이미지 프로퍼티
  
## 🔥 작업 간 발생했던 어려움
- 통신의 방식을 어떻게 할지에 관한 고민이 있었습니다.
    - 지금은 mutating func로 구현되어 있습니다만, 매번 바꾸는 작업을 할 때마다 서버에 요청을 보내고 서버에서 새로운 유저 데이터 모델을 받아오는 방법도 생각해볼 만 합니다.
    - Couple의 경우 you 정보는 수정할 수 없어야 한다고 생각해서 let으로 두었습니다만, 생각해 보면 우리가 가고 싶은 곳을 추가할 때 me, you의 wishlist에서 삭제하고 커플 위시리스트에 추가해야 하는 거라, 수정이 필요하게 될 수도 있겠습니다. 이 부분은 지도를 구현할 때 해결하고자 하여 일단 그대로 두었습니다.

## ❓ 기타
- 우리 쪽의 백엔드와 협의를 거친 후 바뀔 가능성이 있는 부분이 존재합니다.
    - 매번 마이페이지에서 관련 사항을 수정할 때마다 서버에 요청을 보내야 할 지
    - 지금 작성해 둔 스키마가 잘 맞을지: 이 부분은 안드로이드 분들과도 논의해봐야 하는 부분이기도 합니다.
- 지금 보시기에 또 필요한 모델이 있다고 생각되시면 자유롭게 말씀해주시면 감사하겠습니다.

## 🚪 Close issue
Close #15.
