### PR TITLE
[Design] 회원가입 플로우 UI 추가

### DIFF
--- a/Umat/.package.resolved
+++ b/Umat/.package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "popupview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/PopupView",
+      "state" : {
+        "revision" : "41ba4821ca576a937bf0c10e37b18563313c9b6a",
+        "version" : "2.8.5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Umat/Plugins/Umat/ProjectDescriptionHelpers/Dependency+Packages.swift
+++ b/Umat/Plugins/Umat/ProjectDescriptionHelpers/Dependency+Packages.swift
@@ -15,6 +15,7 @@ public extension Package {
 public extension Package.SwiftPackageManager {
     // 사용하고자 하는 패키지가 추가될 때마다 아래 형식을 따라 추가하면 됩니다.
     static let kingfisher = Package.remote(url: "https://github.com/onevcat/Kingfisher", requirement: .upToNextMajor(from: "7.10.2"))
+    static let popupView = Package.remote(url: "https://github.com/exyte/PopupView", requirement: .upToNextMajor(from: "2.8.5"))
 }
 
 public extension TargetDependency {
@@ -27,6 +28,7 @@ public extension TargetDependency {
 public extension TargetDependency.Package {
     // 사용하고자 하는 패키지가 추가될 때마다 아래 형식을 따라 추가하면 됩니다.
     static let kingfisher = TargetDependency.package(product: "Kingfisher")
+    static let popupView = TargetDependency.package(product: "PopupView")
 }
 
 public extension TargetDependency.XCFramework {

--- a/Umat/Projects/App/Umai/Project.swift
+++ b/Umat/Projects/App/Umai/Project.swift
@@ -9,10 +9,12 @@ let project = Project.makeAppModule(
     name: "Umai",
     bundleId: .mainBundleID(),
     product: .app,
+    packages: [.SwiftPackageManager.popupView],
     settings: .appMainSettings,
     dependencies: [
         .feature(implements: .authorization),
-        .shared(implements: .designSystem)
+        .shared(implements: .designSystem),
+        .Package.popupView
     ],
     sources: ["Sources/**"],
     resources: ["Resources/**"],

--- a/Umat/Projects/Feature/Authorization/Project.swift
+++ b/Umat/Projects/Feature/Authorization/Project.swift
@@ -9,10 +9,12 @@ let project = Project.makeAppModule(
     name: "Authorization",
     bundleId: .appBundleID(name: ".Authorization"),
     product: .staticFramework,
+    packages: [.SwiftPackageManager.popupView],
     settings:  .settings(),
     dependencies: [
         .shared(implements: .designSystem),
-        .shared(implements: .entity)
+        .shared(implements: .entity),
+        .Package.popupView
     ],
     sources: ["Sources/**"],
     resources: ["Resources/**"],

--- a/Umat/Projects/Feature/Authorization/Project.swift
+++ b/Umat/Projects/Feature/Authorization/Project.swift
@@ -9,12 +9,10 @@ let project = Project.makeAppModule(
     name: "Authorization",
     bundleId: .appBundleID(name: ".Authorization"),
     product: .staticFramework,
-    packages: [.SwiftPackageManager.popupView],
     settings:  .settings(),
     dependencies: [
         .shared(implements: .designSystem),
         .shared(implements: .entity),
-        .Package.popupView
     ],
     sources: ["Sources/**"],
     resources: ["Resources/**"],

--- a/Umat/Projects/Feature/Authorization/Sources/InputCodeView.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/InputCodeView.swift
@@ -1,0 +1,69 @@
+//
+//  InputCodeView.swift
+//  Authorization
+//
+//  Created by 지준용 on 2/13/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+import Entity
+
+public struct InputCodeView: View {
+    
+    // MARK: - Properties
+    @State private var text: String = ""
+    @State private var supportingText: String = "코드 입력이 잘못되었어요!"
+    @FocusState private var focusState: Bool
+    @State private var stateColor: Color? = nil
+    private let textInputType: TextInputType = .inputCode
+    
+    // MARK: - Init
+    public init() {}
+    
+    // MARK: - Views
+    public var body: some View {
+        VStack {
+            BaseView {
+                TitleHeader(title: textInputType.title,
+                            subTitle: textInputType.subTitle)
+                .padding(.top, 16)
+            } content: {
+                textInput()
+            } footer: {
+                footer()
+            }
+            .padding(.horizontal, 24)
+            .navigationBarBackButton()
+            .hideKeyboardOnTapBackground($focusState)
+            .onAppear {
+                focusState = true
+            }
+        }
+    }
+}
+
+
+fileprivate extension InputCodeView {
+    @ViewBuilder
+    func textInput() -> some View {
+        TextInput(guidanceText: textInputType.guidanceText,
+                  text: $text,
+                  placeholder: textInputType.placeholder,
+                  supportingText: $supportingText,
+                  focusState: $focusState,
+                  stateColor: $stateColor)
+    }
+    
+    @ViewBuilder
+    func footer() -> some View {
+        GrayNavigationLink(text: "입력 완료",
+                           buttonSize: .medium,
+                           buttonState: .disabled) {
+            // TODO: 메인화면으로 이동
+            EmptyView()
+        }
+        .padding(.bottom, 12)
+    }
+}

--- a/Umat/Projects/Feature/Authorization/Sources/InputCodeView.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/InputCodeView.swift
@@ -13,10 +13,8 @@ import Entity
 public struct InputCodeView: View {
     
     // MARK: - Properties
-    @State private var text: String = ""
-    @State private var supportingText: String = "코드 입력이 잘못되었어요!"
     @FocusState private var focusState: Bool
-    @State private var stateColor: Color? = nil
+    @ObservedObject private var viewModel = TextInputViewModel()
     private let textInputType: TextInputType = .inputCode
     
     // MARK: - Init
@@ -37,8 +35,10 @@ public struct InputCodeView: View {
             .padding(.horizontal, 24)
             .navigationBarBackButton()
             .hideKeyboardOnTapBackground($focusState)
+            .sync($viewModel.focusState, with: _focusState)
             .onAppear {
-                focusState = true
+                viewModel.supportingText = "코드 입력이 잘못되었어요!"
+                viewModel.focusState = true
             }
         }
     }
@@ -49,18 +49,18 @@ fileprivate extension InputCodeView {
     @ViewBuilder
     func textInput() -> some View {
         TextInput(guidanceText: textInputType.guidanceText,
-                  text: $text,
+                  text: $viewModel.text,
                   placeholder: textInputType.placeholder,
-                  supportingText: $supportingText,
+                  supportingText: $viewModel.supportingText,
                   focusState: $focusState,
-                  stateColor: $stateColor)
+                  stateColor: $viewModel.stateColor)
     }
     
     @ViewBuilder
     func footer() -> some View {
         GrayNavigationLink(text: "입력 완료",
                            buttonSize: .medium,
-                           buttonState: .disabled) {
+                           buttonState: viewModel.isEnabled ? .enabled : .disabled) {
             // TODO: 메인화면으로 이동
             EmptyView()
         }

--- a/Umat/Projects/Feature/Authorization/Sources/LoginView.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/LoginView.swift
@@ -65,15 +65,14 @@ fileprivate extension LoginView {
                 }
             }
             
-            NavigationLink {
+            CustomNavigationLink(text: "둘러보기",
+                                 font: .pretendard(.semiBold, size: 14),
+                                 foregroundStyle: .colors(.gray600),
+                                 background: .clear,
+                                 height: 34,
+                                 maxWidth: .infinity) {
                 // TODO: 지도로 이동하기
                 EmptyView()
-            } label: {
-                Text("둘러보기")
-                    .pretendard(.semiBold14)
-                    .foregroundStyle(.colors(.gray600))
-                    .frame(height: 34)
-                    .frame(maxWidth: .infinity)
             }
         }
         .padding(.bottom, 16)

--- a/Umat/Projects/Feature/Authorization/Sources/MakeCodeView.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/MakeCodeView.swift
@@ -22,6 +22,7 @@ public struct MakeCodeView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var data: ActivityItem? = nil
     @State private var isWritten = false
+    @State private var isPresented = false
     @State private var isShared = false
     private let model = MakeCodeModel()
     
@@ -47,6 +48,33 @@ public struct MakeCodeView: View {
             } footer: {
                 buttons()
             }
+        }
+        .popup(isPresented: $isPresented) {
+            VStack {
+                Color.white
+                    .frame(height: Metric.statusHeight)
+                
+                if isShared {
+                    toast(icon: .ic_check_outlined,
+                          text: "코드 복사가 완료되었어요!",
+                          backgroundColor: .colors(.gray600))
+                } else if !isWritten {
+                    toast(icon: .ic_warning_outlined,
+                          text: "앗, 상대방이 아직 코드를 입력하지 않았어요!",
+                          backgroundColor: .colors(.error))
+                }
+            }
+        } customize: { view in
+            view
+                .type(.toast)
+                .position(.topLeading)
+                .autohideIn(3)
+                .closeOnTap(false)
+                .dragToDismiss(false)
+                .dismissCallback {
+                    isShared = false
+                    isPresented = false
+                }
         }
     }
 }
@@ -111,6 +139,25 @@ private extension MakeCodeView {
         .padding(.bottom, 64)
     }
     
+    @ViewBuilder
+    func toast(icon: Icons, text: String, backgroundColor: Color) -> some View {
+        HStack(spacing: 6) {
+            Image.icons(icon)
+                .resizable()
+                .renderingMode(.template)
+                .frame(width: 20, height: 20)
+            
+            Text(text)
+                .pretendard(.semiBold12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .foregroundStyle(.white)
+        .padding(.leading, Metric.horizontalPadding)
+        .frame(height: 56)
+        .frame(maxWidth: .infinity)
+        .background(backgroundColor)
+    }
+}
 
 // MARK: - Nested Types
 fileprivate extension MakeCodeView {

--- a/Umat/Projects/Feature/Authorization/Sources/MakeCodeView.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/MakeCodeView.swift
@@ -1,0 +1,130 @@
+//
+//  MakeCodeView.swift
+//  Authorization
+//
+//  Created by 지준용 on 1/31/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+import PopupView
+
+
+// 서버에서 상대방 접속 여부 확인했다는 가정을 위한 간단 모델입니다.
+struct MakeCodeModel {
+    let isConnected: Bool = false
+}
+
+public struct MakeCodeView: View {
+    
+    // MARK: - Properties
+    @Environment(\.dismiss) private var dismiss
+    @State private var data: ActivityItem? = nil
+    @State private var isWritten = false
+    @State private var isShared = false
+    private let model = MakeCodeModel()
+    
+    // MARK: - Init
+    public init() {}
+    
+    // MARK: - Views
+    public var body: some View {
+        VStack {
+            CustomToolBar(leadingIcon: .ic_arrow_back_filled,
+                          leadingAction: {
+                self.dismiss()
+            })
+            
+            BaseView(isContentCentered: false) {
+                TitleHeader(title: "똑똑, 비밀 코드가 도착했어요!",
+                            subTitle: "둘만의 지도를 만들기 위해서 비밀 코드를 드릴게요.",
+                            subTitleFont: .pretendard(.semiBold, size: 14))
+                .padding(.top, Metric.topPadding)
+                .padding(.horizontal, Metric.horizontalPadding)
+            } content: {
+                sharingCode()
+            } footer: {
+                buttons()
+            }
+        }
+    }
+}
+
+private extension MakeCodeView {
+    @ViewBuilder
+    func sharingCode() -> some View {
+        Image(isShared ? Letter.send.rawValue : Letter.send_not.rawValue, bundle: .module)
+            .resizable()
+            .scaledToFit()
+            .frame(height: 243)
+            .padding(.bottom, 16)
+        
+        CustomButton(text: "코드 공유",
+                     font: .pretendard(.semiBold, size: 14),
+                     foregroundStyle: .white,
+                     background: .gradient(),
+                     height: 40,
+                     maxWidth: 91) {
+            // TODO: (서버에서 받은) 코드
+            data = ActivityItem(items: "테스트 메시지")
+        }
+        .activitySheet($data) { activityType, success, items, error in
+            if error != nil {
+                return debugPrint("activitySheet Error: \(error!)")
+            }
+            
+            if success {
+                isPresented = true
+                isShared = true
+            }
+        }
+        .padding(.horizontal, Metric.horizontalPadding)
+        .padding(.bottom, Metric.bottomPadding)
+    }
+    
+    @ViewBuilder
+    func buttons() -> some View {
+        VStack(spacing: 16) {
+            GrayButton(text: "상대방이 코드를 입력했어요",
+                       buttonSize: .medium,
+                       buttonState: isPresented ? .disabled : .enabled) {
+                
+                if !model.isConnected {
+                    self.isPresented = true
+                } else {
+                    isWritten = true
+                }
+            }
+            .navigationDestination(isPresented: $isWritten) {
+                EmptyView()
+            }
+            
+            CustomNavigationLink(text: "상대방 코드 입력",
+                                 foregroundStyle: .colors(.gray800),
+                                 background: .white,
+                                 strokeColor: .colors(.gray300)) {
+                InputCodeView()
+            }
+        }
+        .padding(.horizontal, Metric.horizontalPadding)
+        .padding(.bottom, 64)
+    }
+    
+
+// MARK: - Nested Types
+fileprivate extension MakeCodeView {
+    enum Letter: String {
+        case send
+        case send_not
+    }
+    
+    // MARK: - Enum
+    enum Metric {
+        static let statusHeight: CGFloat = 54
+        static let topPadding: CGFloat = 16
+        static let horizontalPadding: CGFloat = 24
+        static let bottomPadding: CGFloat = 80
+    }
+}
+

--- a/Umat/Projects/Feature/Authorization/Sources/MakeNameView.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/MakeNameView.swift
@@ -1,0 +1,94 @@
+//
+//  MakeNameView.swift
+//  Authorization
+//
+//  Created by 지준용 on 1/27/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+import Entity
+
+
+public struct MakeNameView: View {
+    
+    // MARK: - Properties
+    @ObservedObject private var viewModel = TextInputViewModel()
+    @FocusState private var focusState: Bool
+    private let textInputType: TextInputType = .makeName
+    
+    // MARK: - Init
+    public init() {}
+    
+    // MARK: - View
+    public var body: some View {
+        BaseView {
+            TitleHeader(title: textInputType.title)
+        } content: {
+            textInput()
+        } footer: {
+            nextButton()
+        }
+        .padding(.top, 16)
+        .padding(.horizontal, 24)
+        .padding(.bottom, 12)
+        .navigationBarBackButton()
+        .hideKeyboardOnTapBackground($focusState)
+        .sync($viewModel.focusState, with: _focusState)
+        .onAppear {
+            viewModel.supportingText = "6자 이내, 한글로만 가능해요!"
+            viewModel.focusState = true
+        }
+    }
+}
+
+fileprivate extension MakeNameView {
+    @ViewBuilder
+    func textInput() -> some View {
+        TextInput(guidanceText: textInputType.guidanceText,
+                  text: $viewModel.text,
+                  placeholder: textInputType.placeholder,
+                  supportingText: $viewModel.supportingText,
+                  focusState: $focusState,
+                  stateColor: $viewModel.stateColor)
+        .onChange(of: viewModel.text) { oldValue, newValue in
+            if textInputState(oldValue, newValue) == .enable {
+                viewModel.stateColor = nil
+                viewModel.isEnabled = true
+            } else {
+                viewModel.stateColor = .colors(.error)
+                viewModel.isEnabled = false
+            }
+        }
+    }
+    
+    @ViewBuilder
+    func nextButton() -> some View {
+        GrayNavigationLink(text: "작성 완료",
+                           buttonSize: .medium,
+                           buttonState: viewModel.isEnabled ? .enabled : .disabled) {
+            MakeCodeView()
+        }
+    }
+}
+
+// MARK: - Methods
+extension View {
+    func textInputState(_ oldValue: String, _ newValue: String) -> TextInputState {
+        if !isValidateTextInput(oldValue, newValue) {
+            return .error
+        } else {
+            return .enable
+        }
+    }
+    
+    func isValidateTextInput(_ oldValue: String, _ newValue: String) -> Bool {
+        if (!oldValue.isEmpty && newValue.isEmpty) ||
+            newValue.count > 6 ||
+            !newValue.isKoreanLanguage() {
+            return false
+        }
+        return true
+    }
+}

--- a/Umat/Projects/Feature/Authorization/Sources/VIewModels/TextInputViewModel.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/VIewModels/TextInputViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  TextInputViewModel.swift
+//  Authorization
+//
+//  Created by 지준용 on 2/15/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+public final class TextInputViewModel: ObservableObject {
+    @Published var text: String = ""
+    @Published var supportingText: String = ""
+    @Published var stateColor: Color? = nil
+    @Published var focusState: Bool = false
+    @Published var isEnabled: Bool = false
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Bars/NavigationBar.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Bars/NavigationBar.swift
@@ -1,0 +1,76 @@
+//
+//  NavigationBar.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/15/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+public struct CustomToolBar: View {
+    
+    // MARK: - Properties
+    private let leadingIcon: Icons?
+    private let title: String?
+    private let trailingIcon: Icons?
+    private let leadingAction: (() -> Void)?
+    private let trailingAction: (() -> Void)?
+    
+    // MARK: - Init
+    public init(leadingIcon: Icons? = nil,
+                title: String? = nil,
+                trailingIcon: Icons? = nil,
+                leadingAction: (() -> Void)? = nil,
+                trailingAction: (() -> Void)? = nil) {
+        self.leadingIcon = leadingIcon
+        self.title = title
+        self.trailingIcon = trailingIcon
+        self.leadingAction = leadingAction
+        self.trailingAction = trailingAction
+    }
+    
+    // MARK: - Views
+    public var body: some View {
+        HStack {
+            barItem(icon: leadingIcon, action: leadingAction)
+            
+            Spacer()
+            
+            barItem(icon: trailingIcon, action: trailingAction)
+        }
+        .overlay {
+            navigationTitle()
+        }
+        .padding(.horizontal, 24)
+        .frame(height: 56)
+        .frame(maxWidth: .infinity)
+        .toolbar(.hidden)
+    }
+}
+
+fileprivate extension CustomToolBar {
+    @ViewBuilder
+    func barItem(icon: Icons?, action: (() -> Void)?) -> some View {
+        Button {
+            if let action = action {
+                return action()
+            }
+        } label: {
+            if let icon = icon?.image {
+                icon
+                    .resizable()
+                    .frame(width: 24, height: 24)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    func navigationTitle() -> some View {
+        if let title = title {
+            Text(title)
+                .foregroundStyle(.colors(.gray900))
+                .font(.pretendard(.bold, size: 16))
+        }
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Bars/NavigationBarBackButton.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Bars/NavigationBarBackButton.swift
@@ -9,13 +9,13 @@
 import SwiftUI
 
 public struct NavigationBarBackButton: View {
-    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @Environment(\.dismiss) var dismiss
     
     public init() {}
     
     public var body: some View {
         Button {
-            self.presentationMode.wrappedValue.dismiss()
+            self.dismiss()
         } label: {
             Image.icons(.ic_arrow_back_filled)
                 .resizable()

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/UINavigationController+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/UINavigationController+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  UINavigationController+Extension.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/15/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationController: UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = nil
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return !viewControllers.isEmpty
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/View+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/View+Extension.swift
@@ -34,3 +34,15 @@ public extension View {
             }
     }
 }
+
+public extension View {
+    func sync<T: Equatable>(_ binding: Binding<T>, with focusState: FocusState<T>) -> some View {
+        self
+            .onChange(of: binding.wrappedValue) {
+                focusState.wrappedValue = binding.wrappedValue
+            }
+            .onChange(of: focusState.wrappedValue) {
+                binding.wrappedValue = focusState.wrappedValue
+            }
+    }
+}


### PR DESCRIPTION
## ❗️ 코드를 추가 및 수정한 이유
- 회원가입 공통, 초대코드 생성, 초대코드 입력 뷰를 추가하기 위함.

## 🧾 작업 내용
### UI
- **회원가입 공통**
  - TextInput 입력 사항에 따른 버튼 활성화/비활성화 조건 추가
    - 1글자 이상 6글자 이내
    - 한글만 입력
  - textInputState() 등의 메서드는 다른 TextInput과의 사용성을 비교할 필요가 있어보입니다.
    - 코드입력: 글자수, 제한 언어 및 숫자 등, 서버와의 일치/불일치
- **초대코드 생성**
  - PopupView
    - Toast 동작을 위해 라이브러리를 추가했습니다.
    - Toast동작이 있을 때마다 버튼을 비활성 상태로 두었습니다.
      - Gray버튼을 눌렀을 때만 비활성으로 할 지 고민이 되네요. 오늘 iOS단톡방에 업로드 후 기획/디자인 분들께 컨펌받겠습니다.
- **초대코드 입력**
  - 서버와 연동이 필요한 부분이라 에러 동작은 아직 추가하지 않았습니다.
  
### 그 외
- CustomToolBar 추가
- TextInputViewModel 추가
- Tuist 내 PopupView 라이브러리 의존성 추가

## 🔥 작업 간 발생했던 어려움
- Tuist
  - staticFramework에는 라이브러리를 의존할 수 없다는 사실.. 
- Custom Navigation Swipe
  - SwiftUI 자체 문제로 추정. 어쩌면 애플이 의도한 동작일 수도 있겠습니다.
  - DragGesture를 사용한 Swipe 
    - 기존의 Navigation Swipe와는 달리 뒷 화면이 보여지지 않으며, 동작상의 어색함이 존재
  - UIGestureRecognizerDelegate
    - RootView에서 뒤로가기 시, 앱이 멈추는 문제 발생
    - View를 Touch한 상태로 Swipe를 좌우 반복 시, 이후 앱이 멈추는 문제 발생
    - Background로 내렸다가 다시 Foreground로 올리면 해결되기는 합니다.
    - 또는 다시 Back Swipe 를 하고, Navigation 버튼을 누르면 해결되기도 합니다. 이건 토요일에 기획분들과 이야기를 나누는 게 좋을 듯 싶습니다.


## 📸 스크린샷(선택)
|회원가입 공통|초대코드 생성|초대코드 입력|
|:-:|:-:|:-:|
| ![Simulator Screen Recording - iPhone 13 mini - 2024-02-15 at 23 43 49](https://github.com/DDD-Community/DDD10-TEOPLE-iOS/assets/98405970/b933d1e6-bc71-4a92-a17a-d67784d440ef)|![Simulator Screen Recording - iPhone 13 mini - 2024-02-15 at 23 44 11](https://github.com/DDD-Community/DDD10-TEOPLE-iOS/assets/98405970/56664e42-8b02-44d6-a247-b20f86454ae7)|![Simulator Screen Recording - iPhone 13 mini - 2024-02-15 at 23 45 26](https://github.com/DDD-Community/DDD10-TEOPLE-iOS/assets/98405970/712a8651-fe93-4ebb-bb60-f0dd5517b369)|


## ❓ 기타
- 

## 🚪 Close issue
Close #20.
