### PR TITLE
[Design] CustomBottomSheet, CustomTabView추가

### DIFF
--- a/Umat/Projects/App/Umai/Sources/MainView.swift
+++ b/Umat/Projects/App/Umai/Sources/MainView.swift
@@ -91,7 +91,9 @@ struct MainView: View {
                 isPresented = true
                 isCentered = false
                 
-                offsetY = small // TODO: 위치 수정
+                withAnimation {
+                    offsetY = small
+                }
             case .center:
                 isCentered.toggle()
                 
@@ -105,7 +107,10 @@ struct MainView: View {
     
     private func setupOffsetY(_ medium: CGFloat, _ small: CGFloat) {
         if isSelectedItem == .left {
-            offsetY = isCentered ? medium : small
+            withAnimation {
+                offsetY = isCentered ? medium : small
+            }
+            
             isPresented = true
         } else {
             offsetY = isCentered ? medium : .infinity

--- a/Umat/Projects/App/Umai/Sources/MainView.swift
+++ b/Umat/Projects/App/Umai/Sources/MainView.swift
@@ -1,0 +1,119 @@
+//
+//  MainView.swift
+//  Umai
+//
+//  Created by 지준용 on 2/19/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+import Entity
+
+struct MainView: View {
+    @State private var isSelectedItem: TabItem = .left
+    @State private var isPresented: Bool = true
+    @State private var isCentered: Bool = false
+    @State private var sheetHeight: CGFloat = 0
+    @State private var offsetY: CGFloat = 0
+    
+    var body: some View {
+        let small = sheetHeight - BottomSheetOffset.small
+        let medium = sheetHeight * BottomSheetOffset.mediumRate
+        
+        CustomTabView(isSelectedItem: $isSelectedItem) { item in
+            ZStack {
+                switch item {
+                case .left:
+                    
+                    // TODO: 지도뷰
+                    Text("지도")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(.yellow)
+                    
+                    VStack(spacing: 32) {
+                        RoundedRectangle(cornerRadius: 8) // 검색창 위치
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 46)
+                            .padding(.horizontal, 24)
+                        
+                        Spacer()
+                    }
+                case .center:
+                    EmptyView()
+                
+                case .right:
+                    
+                    // TODO: 마이페이지 뷰
+                    Text("마이페이지")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(.red)
+                }
+                
+                ZStack(alignment: .bottom) {
+                    Color.black
+                        .opacity(isCentered ? 0.4 : 0)
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            isCentered = false
+                            
+                            setupOffsetY(medium, small)
+                        }
+                    
+                    VStack(spacing: 32) {
+                        Spacer()
+                            .frame(height: 46)
+                        
+                        GeometryReader { geometry in
+                            BottomSheet(offsetY: $offsetY,
+                                        sheetHeight: sheetHeight,
+                                        content: {
+                                
+                                // TODO: 바텀시트 컨텐츠
+                                VStack {
+                                    ForEach(0..<100, id: \.self) {_ in
+                                        Text("테스트용")
+                                    }
+                                }
+                            })
+                            .onAppear {
+                                sheetHeight = geometry.size.height
+                                offsetY = sheetHeight
+                            }
+                        }
+                        .opacity(isPresented ? 1 : 0)
+                    }
+                }
+            }
+        } onTappedItem: { item in
+            switch item {
+            case .left:
+                isPresented = true
+                isCentered = false
+                
+                offsetY = small // TODO: 위치 수정
+            case .center:
+                isCentered.toggle()
+                
+                setupOffsetY(medium, small)
+            case .right:
+                isPresented = false
+                isCentered = false
+            }
+        }
+    }
+    
+    private func setupOffsetY(_ medium: CGFloat, _ small: CGFloat) {
+        if isSelectedItem == .left {
+            offsetY = isCentered ? medium : small
+            isPresented = true
+        } else {
+            offsetY = isCentered ? medium : .infinity
+            isPresented.toggle()
+        }
+    }
+}
+
+#Preview {
+    MainView()
+}

--- a/Umat/Projects/Feature/Authorization/Sources/MakeCodeView.swift
+++ b/Umat/Projects/Feature/Authorization/Sources/MakeCodeView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import DesignSystem
+
 import PopupView
 
 

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/ScrollView+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/ScrollView+Extension.swift
@@ -1,0 +1,25 @@
+//
+//  ScrollView+Extension.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/18/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+public struct ScrollViewModifier: ViewModifier {
+    public init(isBounce: Bool) {
+        UIScrollView.appearance().bounces = isBounce
+    }
+
+    public func body(content: Content) -> some View {
+        content
+    }
+}
+
+extension ScrollView {
+    public func isBounce(_ isBounce: Bool) -> some View {
+        self.modifier(ScrollViewModifier(isBounce: isBounce))
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/View+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/View+Extension.swift
@@ -46,3 +46,23 @@ public extension View {
             }
     }
 }
+
+// MARK: - RoundedCorner
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect,
+                                byRoundingCorners: corners,
+                                cornerRadii: CGSize(width: radius,
+                                                    height: radius))
+        return Path(path.cgPath)
+    }
+}
+
+public extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/View+Extension.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Extensions+/View+Extension.swift
@@ -8,6 +8,8 @@
 
 import SwiftUI
 
+
+// MARK: - HideKeyboard
 public extension View {
     @ViewBuilder 
     func hideKeyboardOnTapBackground( _ focusState: FocusState<Bool>.Binding,
@@ -22,6 +24,7 @@ public extension View {
     }
 }
 
+// MARK: - navigationBarBackButton
 public extension View {
     @ViewBuilder 
     func navigationBarBackButton() -> some View {
@@ -35,6 +38,7 @@ public extension View {
     }
 }
 
+// MARK: - SyncFocusState
 public extension View {
     func sync<T: Equatable>(_ binding: Binding<T>, with focusState: FocusState<T>) -> some View {
         self

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
@@ -18,8 +18,8 @@ public struct BottomSheet<Content: View>: View {
     
     // MARK: - Properties
     @StateObject private var viewModel = BottomSheetViewModel()
-    @State var translation: CGSize = .zero
-    @Binding var offsetY: CGFloat
+    @State private var translation: CGSize = .zero
+    @Binding private var offsetY: CGFloat
     private let sheetHeight: CGFloat
     private let content: () -> Content
     

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
@@ -1,0 +1,144 @@
+//
+//  BottomSheet.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/19/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+public enum BottomSheetOffset {
+    public static let small: CGFloat = 160
+    public static let mediumRate: CGFloat = 0.35
+    public static let large: CGFloat = 0
+}
+
+public struct BottomSheet<Content: View>: View {
+    
+    // MARK: - Properties
+    @StateObject private var viewModel = BottomSheetViewModel()
+    @State var translation: CGSize = .zero
+    @Binding var offsetY: CGFloat
+    private let sheetHeight: CGFloat
+    private let content: () -> Content
+    
+    private var sheetOffset: CGFloat {
+        let current = translation.height + offsetY
+        let medium = sheetHeight * BottomSheetOffset.mediumRate
+        let small = sheetHeight - BottomSheetOffset.small
+        
+        if current >= (medium+small / 2) {
+            return small
+        } else if current > 50 {
+            return current
+        }
+        return BottomSheetOffset.large
+    }
+    
+    // MARK: - Init
+    public init(offsetY: Binding<CGFloat>,
+                sheetHeight: CGFloat,
+                @ViewBuilder content: @escaping () -> Content) {
+        self._offsetY = offsetY
+        self.sheetHeight = sheetHeight
+        self.content = content
+    }
+    
+    // MARK: - Views
+    public var body: some View {
+        ScrollView {
+            scrollObservableView()
+            
+            content()
+                .padding(.bottom, 100)
+        }
+        .isBounce(false)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.white)
+        .cornerRadius(16, corners: [.topLeft, .topRight])
+        .ignoresSafeArea(edges: .bottom)
+        .scrollDisabled(isDisabledScroll())
+        .scrollIndicators(.never)
+        .offset(y: sheetOffset)
+        .gesture(
+            DragGesture()
+                .onChanged { gesture in
+                    scrollDirection(gesture)
+                    
+                    translation = gesture.translation
+                }
+                .onEnded { gesture in
+                    viewModel.setupDirect(.none)
+                    
+                    withAnimation(.linear(duration: 0.1)) {
+                        configureBottomSheetOffsetY()
+                        
+                        translation = .zero
+                    }
+                }
+        )
+        .onPreferenceChange(ScrollOffsetKey.self) {
+            viewModel.setupOffset($0)
+        }
+    }
+}
+
+fileprivate extension BottomSheet {
+    @ViewBuilder
+    func scrollObservableView() -> some View {
+        GeometryReader { proxy in
+            let offsetY = proxy.frame(in: .global).origin.y
+            
+            Color.clear
+                .preference(
+                    key: ScrollOffsetKey.self,
+                    value: offsetY
+                )
+                .onAppear {
+                    viewModel.setupOriginOffset(offsetY)
+                }
+        }
+    }
+}
+
+// MARK: - Methods
+fileprivate extension BottomSheet {
+    func isDisabledScroll() -> Bool {
+        if offsetY > BottomSheetOffset.large {
+            return true
+        }
+        
+        if viewModel.direct == .down && (viewModel.offset - BottomSheetOffset.small) == (viewModel.originOffset) {
+            return true
+        }
+        
+        return false
+    }
+    
+    func scrollDirection(_ gesture: _ChangedGesture<DragGesture>.Value) {
+        let snap = gesture.translation.height
+        
+        if snap > 0 {
+            viewModel.setupDirect(.down)
+        } else if snap < 0 {
+            viewModel.setupDirect(.up)
+        } else {
+            viewModel.setupDirect(.none)
+        }
+    }
+    
+    func configureBottomSheetOffsetY() {
+        let current = translation.height + offsetY
+        let medium = sheetHeight * BottomSheetOffset.mediumRate
+        let small = sheetHeight - BottomSheetOffset.small
+        
+        if current > (BottomSheetOffset.large + medium)/2 && current < (medium+small)/2 {
+            offsetY = sheetHeight * BottomSheetOffset.mediumRate // Medium
+        } else if current > (medium+small)/2 {
+            offsetY = sheetHeight - BottomSheetOffset.small // Small
+        } else {
+            offsetY = BottomSheetOffset.large // Large
+        }
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
@@ -51,7 +51,10 @@ public struct BottomSheet<Content: View>: View {
             scrollObservableView()
             
             content()
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 24)
                 .padding(.bottom, 100)
+                .background(.white)
         }
         .isBounce(false)
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheet.swift
@@ -30,7 +30,7 @@ public struct BottomSheet<Content: View>: View {
         
         if current >= (medium+small / 2) {
             return small
-        } else if current > 50 {
+        } else if current > 25 {
             return current
         }
         return BottomSheetOffset.large

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheetViewModel.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/BottomSheetViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  BottomSheetViewModel.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/19/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+final class BottomSheetViewModel: ObservableObject {
+    
+    // MARK: - Enum
+    enum Direct {
+        case none
+        case up
+        case down
+    }
+    
+    // MARK: - Properties
+    @Published private(set) var offset: CGFloat = 0
+    @Published private(set) var direct: Direct = .none
+    private(set) var originOffset: CGFloat = 0
+    private var isCheckedOriginOffset: Bool = false
+    
+    // MARK: - Methods
+    func setupOriginOffset(_ offset: CGFloat) {
+        guard !isCheckedOriginOffset else { return }
+        self.originOffset = offset
+        self.offset = offset
+        isCheckedOriginOffset = true
+    }
+    
+    func setupOffset(_ offset: CGFloat) {
+        guard isCheckedOriginOffset else { return }
+        self.offset = offset
+    }
+    
+    func setupDirect(_ direct: Direct) {
+        guard isCheckedOriginOffset else { return }
+        self.direct = direct
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/ScrollOffsetKey.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/Sheets/ScrollOffsetKey.swift
@@ -1,0 +1,17 @@
+//
+//  ScrollOffsetKey.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/19/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+struct ScrollOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+    
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value += nextValue()
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/TabView/CustomTabView.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/TabView/CustomTabView.swift
@@ -1,0 +1,99 @@
+//
+//  CustomTabView.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/19/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+import Entity
+
+
+public struct CustomTabView<Content: View>: View {
+    
+    // MARK: - Properties
+    @Binding private var isSelectedItem: TabItem
+    private let content: (TabItem) -> Content
+    private let onTappedItem: ((TabItem) -> Void)?
+    
+    // MARK: - Init
+    public init(isSelectedItem: Binding<TabItem>,
+         @ViewBuilder content: @escaping (TabItem) -> Content,
+         onTappedItem: ((TabItem) -> Void)? = nil) {
+        self._isSelectedItem = isSelectedItem
+        self.content = content
+        self.onTappedItem = onTappedItem
+    }
+    
+    // MARK: - Views
+    public var body: some View {
+        ZStack {
+            content(isSelectedItem)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            
+            VStack(spacing: 0) {
+                Divider()
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+                
+                HStack() {
+                    buttons()
+                }
+                .frame(maxWidth: .infinity)
+                .ignoresSafeArea(edges: .horizontal)
+                .background(.white)
+            }
+        }
+    }
+}
+
+fileprivate extension CustomTabView {
+    @ViewBuilder
+    func buttons() -> some View {
+        ForEach(TabItem.allCases, id: \.self) { item in
+            Button {
+                if !item.text.isEmpty {
+                    isSelectedItem = item
+                }
+                
+                action(item: item)
+            } label: {
+                buttonLabel(item: item)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 12)
+        }
+    }
+    
+    @ViewBuilder
+    func buttonLabel(item: TabItem) -> some View {
+        if item.text.isEmpty {
+            item.image
+                .resizable()
+                .renderingMode(.template)
+                .scaledToFit()
+                .foregroundStyle(.colors(.gray900))
+                .frame(width: item.imageSize, height: item.imageSize)
+        } else {
+            VStack(spacing: 2) {
+                item.image
+                    .resizable()
+                    .renderingMode(.template)
+                    .scaledToFit()
+                    .foregroundStyle(isSelectedItem == item ? item.selectedColor : item.unsSelectedColor)
+                    .frame(width: item.imageSize, height: item.imageSize)
+                
+                Text(item.text)
+                    .pretendard(.medium12)
+                    .foregroundStyle(isSelectedItem == item ? item.selectedColor : item.unsSelectedColor)
+            }
+        }
+    }
+    
+    // MARK: - Methods
+    func action(item: TabItem) {
+        guard onTappedItem != nil else { return }
+        
+        onTappedItem!(item)
+    }
+}

--- a/Umat/Projects/Shared/DesignSystem/Sources/Component/TabView/TabItem.swift
+++ b/Umat/Projects/Shared/DesignSystem/Sources/Component/TabView/TabItem.swift
@@ -1,0 +1,48 @@
+//
+//  TabItem.swift
+//  DesignSystem
+//
+//  Created by 지준용 on 2/19/24.
+//  Copyright © 2024 KYUNG MIN CHOI. All rights reserved.
+//
+
+import SwiftUI
+
+
+public enum TabItem: CaseIterable {
+    case left
+    case center
+    case right
+
+    var image: Image {
+        switch self {
+        case .left: .icons(.ic_home_outlined)
+        case .center: .init(systemName: "plus.app.fill")
+        case .right: .icons(.ic_my_outlined)
+        }
+    }
+    
+    var text: String {
+        switch self {
+        case .left: "홈"
+        case .center: ""
+        case .right: "마이페이지"
+        }
+    }
+    
+    var selectedColor: Color {
+        return .colors(.gray800)
+    }
+    
+    var unsSelectedColor: Color {
+        return .colors(.gray300)
+    }
+    
+    var imageSize: CGFloat {
+        if text.isEmpty {
+            return 42
+        } else {
+            return 24
+        }
+    }
+}


### PR DESCRIPTION
## ❗️ 코드를 추가 및 수정한 이유
- 앱의 메인화면에 적용될 BottomSheet, TabView를 적용하기 위함.
  - TabView 뒤에 HalfModal이 등장해야 함.
  - TabView의 기본 규격과는 다른 TabVIew를 사용해야 함.

## 🧾 작업 내용
- **MainView**
  - 메인 화면으로, 지도와 마이페이지가 포함되는 뷰를 추가했습니다.
  - CustomTabView, CustomBottomSheet 적용
- **BottomSheet**
  - 요구사항
    - TabView와의 연동
      - 홈(지도) 탭: small BottomSheet
      - Plus(추가하기) 탭: Medium BottomSheet
      - 마이페이지: BottomSheet 숨기기
    - BottomSheet 내 스크롤 동작
      - BottomSheet가 최대 크기가 되어야 스크롤 가능하도록 구현
      - ScrollView의 최상단 위치 관찰 기능 추가
      - ScrollView가 최상단에 위치할 때에는 단방향 스크롤(아래)만 가능하도록 구현
      - ScrollView의 최상단 위치가 변화하지 않도록 Bounce 동작 제거
  - 디자인시스템으로 범용성있는 구현은 어렵다는 생각입니다. 
 
- **TabView**
  - 홈, 마이페이지 탭만 페이지 전환 기능 적용
  - 추가하기 탭 클릭 시, BottomSheet 및 Dim 처리 적용
## 🔥 작업 간 발생했던 어려움
- Drag가 되는 BottomSheet 내에서, 중복 동작을 내포하는 ScrollView를 적용하는 과정이 까다로웠습니다. (사실 HIG에서는 그다지 추천하지 않는 동작이죠..)
  - 스크롤 동작의 방향, 스크롤뷰 컨텐츠의 위치 등을 인식해 BottomSheet에 Drag동작을 적용했습니다.
  - 또한 BottomSheet가 Bounce한 동작이 있으면, TabView 아래로 Sheet가 잠깐 내려가거나, TabView 위로 Sheet가 빠져나오는 동작이 있을 수 있어, BottomSheet Drag의 최대, 최소 위치를 적용해야했습니다.
  - 조금 아쉬운 미구현된 부분은 손가락을 살짝 튕겨서 올려 Small -> Medium, Medium -> Large 사이즈로 이동하는 동작 구현은 되어있지 않습니다. 현재 사용자의 스크롤 위치에 따라 가까운 사이즈로 이동하도록 구현했습니다.
    -  Small에 가까우면 Small, Medium에 가까우면 Medium

## 📸 스크린샷(선택)
<img src="https://github.com/DDD-Community/DDD10-TEOPLE-iOS/assets/98405970/f0eadefa-6db1-4ed1-bbfd-8bd18f63b766" width=300>


## ❓ 기타
- BottomSheet는 제가 만들었던 View 중 고난도에 속하지 않을까.. 라는 생각이 듭니다. 근데 SwiftUI라서 간단하게 구현이 된 것 같기도 하네요. UIKit이었다면 코드가 2배 이상 늘었을 것 같습니다.
- BottomSheet와 TabView는 디자인 컴포넌트에 포함시켜두었으나, MainView에 반영해두었기 때문에 따로 사용하지 않으셔도 됩니다.
- 코드를 최대한 적게 PR을 올리고 싶은데, 남은 기간이 얼마 안 남아서 인지 계속 한 번에 올리는 내용이 많아지네요..

## 🚪 Close issue
Close #23.
